### PR TITLE
Added operations notEqualOrIsNull and notInOrIsNull

### DIFF
--- a/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/operation/FieldOperation.java
+++ b/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/operation/FieldOperation.java
@@ -12,6 +12,7 @@ import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operatio
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations.OperationLike;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations.OperationNotEqual;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations.OperationNotEqualOrIsNull;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations.OperationNotInOrIsNull;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.transforms.OperationTransformCast;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.transforms.OperationTransformDate;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.transforms.OperationTransformFunction;
@@ -40,6 +41,7 @@ public class FieldOperation<ObjBack, SelectTable, Table, Type>
 			OperationIsNull<ObjBack, SelectTable, Table, Type>,
 			OperationBetween<ObjBack, SelectTable, Table, Type>,
 			OperationIn<ObjBack, SelectTable, Table, Type>,
+			OperationNotInOrIsNull<ObjBack, SelectTable, Table, Type>,
 			OperationLike<ObjBack, SelectTable, Table, Type>,
 			
 			ToSql {

--- a/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/operation/FieldOperation.java
+++ b/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/operation/FieldOperation.java
@@ -11,6 +11,7 @@ import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operatio
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations.OperationLessThan;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations.OperationLike;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations.OperationNotEqual;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations.OperationNotEqualOrIsNull;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.transforms.OperationTransformCast;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.transforms.OperationTransformDate;
 import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.transforms.OperationTransformFunction;
@@ -31,6 +32,7 @@ public class FieldOperation<ObjBack, SelectTable, Table, Type>
 			
 			OperationEqual<ObjBack, SelectTable, Table, Type>,
 			OperationNotEqual<ObjBack, SelectTable, Table, Type>,
+			OperationNotEqualOrIsNull<ObjBack, SelectTable, Table, Type>,
 			OperationLessThan<ObjBack, SelectTable, Table, Type>,
 			OperationLessOrEqualThan<ObjBack, SelectTable, Table, Type>,
 			OperationGreaterThan<ObjBack, SelectTable, Table, Type>,

--- a/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/operation/operations/OperationNotEqualOrIsNull.java
+++ b/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/operation/operations/OperationNotEqualOrIsNull.java
@@ -1,0 +1,55 @@
+package com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations;
+
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.Operations;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.ref.FieldRef;
+
+public interface OperationNotEqualOrIsNull<ObjBack, SelectTable, Table, Type> extends OperationBase<ObjBack, SelectTable, Table, Type> {
+
+	/**
+	 * Execute operation (NOT EQUAL <em>val</em> OR IS NULL)
+	 * <ul>
+	 * <li>JPQL: (e.firstName != 'Bob' or e.firstName is null)
+	 * </ul>
+	 * @return back
+	 */
+	default Operations<ObjBack,SelectTable, Table> notEqualOrIsNull(Type value) {
+
+		this.setSql("(" + this.toSql() + " != :" + this.createParam(value) + " OR " + this.toSql() + " IS NULL)");
+		return end();
+	}
+
+	/**
+	 * Execute operation (NOT EQUAL <em>val</em> OR IS NULL)
+	 * <ul>
+	 * <li>JPQL: (e.firstName != 'Bob' or e.firstName is null)
+	 * </ul>
+	 * @return back
+	 */
+	default Operations<ObjBack,SelectTable, Table> neOrNull(Type value) {
+		return this.notEqualOrIsNull(value);
+	}
+
+	/**
+	 * Execute operation (NOT EQUAL <em>val</em> OR IS NULL)
+	 * <ul>
+	 * <li>JPQL: (e.firstName != f.firstName or e.firstName is null)
+	 * </ul>
+	 * @return back
+	 */
+	default Operations<ObjBack,SelectTable, Table> notEqualOrIsNull(FieldRef<?> field) {
+		this.setSql("(" + this.toSql() + " != " + field.getSql()  + " OR " + this.toSql() + " IS NULL)");
+		return this.end();
+	}
+
+	/**
+	 * Execute operation (NOT EQUAL <em>val</em> OR IS NULL)
+	 * <ul>
+	 * <li>JPQL: (e.firstName != f.firstName or e.firstName is null)
+	 * </ul>
+	 * @return back
+	 */
+	default Operations<ObjBack,SelectTable, Table> neOrNull(FieldRef<?> field) {
+		return this.notEqualOrIsNull(field);
+	}
+
+}

--- a/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/operation/operations/OperationNotInOrIsNull.java
+++ b/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/operation/operations/OperationNotInOrIsNull.java
@@ -1,0 +1,53 @@
+package com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.operations;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.StringJoiner;
+
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.operation.Operations;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.ref.FieldRef;
+
+@SuppressWarnings("unchecked")
+public interface OperationNotInOrIsNull<ObjBack, SelectTable, Table, Type> extends OperationBase<ObjBack, SelectTable, Table, Type> {
+
+	/**
+	 * Execute operation (NOT IN (...) OR IS NULL)
+	 * <ul>
+	 * <li>JPQL: (e.firstName NOT IN ('Bob', 'Fred', 'Joe') or e.firstName is null)
+	 * </ul>
+	 * @return back
+	 */
+	default Operations<ObjBack,SelectTable, Table> notInOrIsNull(Collection<Type> value) {
+		this.setSql("(" + this.toSql() + " NOT IN :" + this.createParam(value) + " OR " + this.toSql() + " IS NULL)");
+		return end();
+	}
+
+	/**
+	 * Execute operation (NOT IN (...) OR IS NULL)
+	 * <ul>
+	 * <li>JPQL: (e.firstName NOT IN ('Bob', 'Fred', 'Joe') or e.firstName is null)
+	 * </ul>
+	 * @return back
+	 */
+	default Operations<ObjBack,SelectTable, Table> notInOrIsNull(Type ...value) {
+		this.notInOrIsNull(Arrays.asList(value));
+		return end();
+	}
+
+	/**
+	 * Execute operation (NOT IN (...) OR IS NULL)
+	 * <ul>
+	 * <li>JPQL: (e.firstName NOT IN ('Bob', 'Fred', 'Joe') or e.firstName is null)
+	 * </ul>
+	 * @return back
+	 */
+	default Operations<ObjBack,SelectTable, Table> notInOrIsNull(FieldRef<?> ...field) {
+		StringJoiner sj = new StringJoiner(", ", "(", ")");
+		for (FieldRef<?> f : field) {
+			sj.add(f.getSql());
+		}
+		this.setSql("(" + this.toSql() + " NOT IN " + sj.toString() + " OR " + this.toSql() + " IS NULL)");
+		return this.end();
+	}
+
+}

--- a/lib/src/test/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/where/operation/WhereNeOrNullTest.java
+++ b/lib/src/test/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/where/operation/WhereNeOrNullTest.java
@@ -1,0 +1,125 @@
+package com.ordnaelmedeiros.jpafluidselect.querybuilder.where.operation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.QueryBuilder;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.models.ObjString;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.models.ObjString_;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.ref.Ref;
+
+public class WhereNeOrNullTest {
+
+	private static EntityManagerFactory emf;
+	public EntityManager em;
+	public QueryBuilder queryBuilder;
+
+	@BeforeClass
+	public static void beforeClass() {
+
+		emf = Persistence.createEntityManagerFactory("h2");
+
+		EntityManager em = emf.createEntityManager();
+		em.getTransaction().begin();
+
+		em.createQuery("delete from ObjString").executeUpdate();
+
+		em.persist(new ObjString(1, "A"));
+		em.persist(new ObjString(2, null));
+		em.persist(new ObjString(3, "C"));
+		em.persist(new ObjString(4, "D"));
+
+		em.getTransaction().commit();
+
+	}
+
+	@Before
+	public void before() {
+
+		em = emf.createEntityManager();
+		queryBuilder = new QueryBuilder(em);
+
+	}
+
+	@Test
+	public void noOrNull() {
+
+		List<ObjString> result = queryBuilder
+			.select(ObjString.class)
+			.where()
+				.field(ObjString_.text).neOrNull("C")
+				.field(ObjString_.id).notEqualOrIsNull(4)
+			.order()
+				.asc(ObjString_.id)
+			.print()
+			.getResultList();
+
+		assertThat(result, notNullValue());
+		assertThat(result.size(), is(2));
+		assertThat(result.get(0).getId(), is(1));
+		assertThat(result.get(0).getText(), is("A"));
+		assertThat(result.get(1).getId(), is(2));
+		assertThat(result.get(1).getText(), nullValue());
+	}
+
+	@Test
+	public void noOrNullOrGroup() {
+
+		List<ObjString> result = queryBuilder
+			.select(ObjString.class)
+			.where()
+				.orGroup()
+					.field(ObjString_.text).neOrNull("C")
+					.field(ObjString_.id).notEqualOrIsNull(4)
+				.end()
+			.order()
+				.asc(ObjString_.id)
+			.print()
+			.getResultList();
+
+		assertThat(result, notNullValue());
+		assertThat(result.size(), is(4));
+		assertThat(result.get(0).getId(), is(1));
+		assertThat(result.get(0).getText(), is("A"));
+		assertThat(result.get(1).getId(), is(2));
+		assertThat(result.get(1).getText(), nullValue());
+
+		assertThat(result.get(2).getId(), is(3));
+		assertThat(result.get(2).getText(), is("C"));
+		assertThat(result.get(3).getId(), is(4));
+		assertThat(result.get(3).getText(), is("D"));
+	}
+
+	@Test
+	public void eqByRef() {
+
+		Ref<ObjString> ref = new Ref<>();
+		List<ObjString> result = queryBuilder
+			.select(ObjString.class).ref(ref)
+			.where()
+				.field(ObjString_.text).neOrNull(ref.field(ObjString_.text))
+			.order()
+				.asc(ObjString_.id)
+			.print()
+			.getResultList();
+
+		assertThat(result, notNullValue());
+		assertThat(result.size(), is(1));
+		assertThat(result.get(0).getId(), is(2));
+		assertThat(result.get(0).getText(), nullValue());
+
+	}
+
+}

--- a/lib/src/test/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/where/operation/WhereNotInOrIsNullTest.java
+++ b/lib/src/test/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/where/operation/WhereNotInOrIsNullTest.java
@@ -1,0 +1,113 @@
+package com.ordnaelmedeiros.jpafluidselect.querybuilder.where.operation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.time.Month;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.QueryBuilder;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.models.ObjDate;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.models.ObjDate_;
+import com.ordnaelmedeiros.jpafluidselect.querybuilder.select.ref.Ref;
+
+public class WhereNotInOrIsNullTest {
+
+	private static EntityManagerFactory emf;
+	public EntityManager em;
+	public QueryBuilder queryBuilder;
+
+	@BeforeClass
+	public static void beforeClass() {
+
+		emf = Persistence.createEntityManagerFactory("h2");
+
+		EntityManager em = emf.createEntityManager();
+		em.getTransaction().begin();
+		em.createQuery("delete from ObjDate").executeUpdate();
+
+		em.persist(new ObjDate(1, 2016, Month.JUNE, 13));
+		em.persist(new ObjDate(2, 2017, Month.JULY, 14));
+		em.persist(new ObjDate(3, null));
+		em.persist(new ObjDate(4, 2019, Month.AUGUST, 16));
+
+		em.getTransaction().commit();
+
+	}
+
+	@Before
+	public void before() {
+
+		em = emf.createEntityManager();
+		queryBuilder = new QueryBuilder(em);
+
+	}
+
+	@Test
+	public void dateIn2017_2019() {
+
+		List<ObjDate> result = queryBuilder
+			.select(ObjDate.class)
+			.where()
+				.field(ObjDate_.date).year().notInOrIsNull(2017, 2019)
+			.order()
+				.asc(ObjDate_.id)
+			.print()
+			.getResultList();
+
+		assertThat(result, notNullValue());
+		assertThat(result.size(), is(2));
+		assertThat(result.get(0).getId(), is(1));
+		assertThat(result.get(1).getId(), is(3));
+
+		List<Integer> years = Arrays.asList(2017, 2019);
+
+		result = queryBuilder
+			.select(ObjDate.class)
+			.where()
+				.field(ObjDate_.date).year().notInOrIsNull(years)
+			.order()
+				.asc(ObjDate_.id)
+			.print()
+			.getResultList();
+
+		assertThat(result, notNullValue());
+		assertThat(result.size(), is(2));
+		assertThat(result.get(0).getId(), is(1));
+		assertThat(result.get(1).getId(), is(3));
+
+	}
+
+
+	@Test
+	public void dateIn2017_2019_ref() {
+
+		Ref<ObjDate> ref = new Ref<>();
+		List<ObjDate> result = queryBuilder
+			.select(ObjDate.class).ref(ref)
+			.where()
+				.field(ObjDate_.date).year().notInOrIsNull(
+					ref.field(ObjDate_.date).year()
+				)
+			.order()
+				.asc(ObjDate_.id)
+			.print()
+			.getResultList();
+
+		assertThat(result, notNullValue());
+		assertThat(result.size(), is(1));
+		assertThat(result.get(0).getId(), is(3));
+
+	}
+
+}


### PR DESCRIPTION
Implementations of the operations `notEqualOrIsNull` (_field_ != _val_ OR _field_ IS NULL), the idea is to have the same behavior as _!var.equals(null)_ in java.

Also added the operation `notInOrIsNull` (_field_ NOT IN ( _val1, val2_ ) OR _field_ IS NULL).