### PR TITLE
Join fetch

### DIFF
--- a/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/join/Join.java
+++ b/lib/src/main/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/select/join/Join.java
@@ -54,6 +54,8 @@ public class Join<ObjBack, SelectTable, Table>
 	@Setter
 	private JoinType joinType  = JoinType.INNER;
 
+	private String fetchFlag = "";
+
 	public Join(ObjBack objBack, Select<SelectTable> select, String aliasOrigin, String field) {
 		
 		this.aliasOrigin = aliasOrigin;
@@ -84,7 +86,7 @@ public class Join<ObjBack, SelectTable, Table>
 	
 	@Override
 	public String toSql() {
-		String sql = this.joinType+" JOIN "+aliasOrigin+"." + field + " " + aliasJoin + " \n";
+		String sql = this.joinType+" JOIN "+fetchFlag+aliasOrigin+"." + field + " " + aliasJoin + " \n";
 		sql += this.on.toSql() + "\n";
 		for (Join<?, ?, ?> join : this.joins) {
 			sql += join.toSql() + " \n";
@@ -106,8 +108,13 @@ public class Join<ObjBack, SelectTable, Table>
 		
 		return this;
 	}
-	
-	
+
+	public Join<ObjBack, SelectTable, Table> fetch() {
+		this.fetchFlag = " FETCH ";
+		return this;
+	}
+
+
 	public Join<Join<ObjBack, SelectTable, Table>, SelectTable, ?> innerJoin(String field) {
 		Join<Join<ObjBack, SelectTable, Table>, SelectTable, ?> join = new Join<>(this, this.getSelect(), this.aliasJoin, field);
 		join.setJoinType(JoinType.INNER);

--- a/lib/src/test/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/join/JoinTest.java
+++ b/lib/src/test/java/com/ordnaelmedeiros/jpafluidselect/querybuilder/join/JoinTest.java
@@ -3,6 +3,7 @@ package com.ordnaelmedeiros.jpafluidselect.querybuilder.join;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -12,6 +13,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.hibernate.LazyInitializationException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -193,5 +195,37 @@ public class JoinTest {
 		assertThat(result.get(0)[2], is("5546999145929"));
 		
 	}
-	
+
+	@Test
+	public void expectLazyInitializationExceptionFromDetachList() {
+
+		Employee employee = new QueryBuilder(em)
+			.select(Employee.class)
+			.innerJoin(Employee_.phones).end()
+			.maxResults(1)
+			.getSingleResult();
+
+		em.detach(employee);
+		try {
+			employee.getPhones().get(0);
+			fail("should have thrown a LazyInitializationException");
+		} catch(LazyInitializationException e) {
+			// Expected result
+		}
+	}
+
+	@Test
+	public void fetchJoin() {
+
+		Employee employee = new QueryBuilder(em)
+			.select(Employee.class)
+			.innerJoin(Employee_.phones).fetch().end()
+			.maxResults(1)
+			.getSingleResult();
+
+		em.detach(employee);
+		EmployeePhone phone = employee.getPhones().get(0);
+		assertThat(phone, notNullValue());
+	}
+
 }


### PR DESCRIPTION
Added the possibility of `FETCH` to joins.
Ex:
> `.leftJoin(Entity_.field).fetch()`
> that performs a `LEFT JOIN FETCH field`